### PR TITLE
add prost-types as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 substreams = "0.5.0"
 substreams-ethereum = "0.9.0"
 prost = "0.11"
+prost-types = "0.11.8"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
When I followed the quickstart, I needed to add this dependency in order to run `substreams protogen substreams.yaml`